### PR TITLE
Extract app_state in fixed_node macro

### DIFF
--- a/src/clientnode.rs
+++ b/src/clientnode.rs
@@ -566,6 +566,7 @@ macro_rules! fixed_node {
                 if $request.shv_path().unwrap_or_default().is_empty() {
                     let mut __resp = $request.prepare_response().unwrap_or_default();
                     let __client_cmd_tx_clone = $client_cmd_tx.clone();
+                    $(let $app_state = $app_state.expect("Application state should be Some");)?
                     let resp_value: Option<std::result::Result<$crate::clientnode::RpcValue, $crate::clientnode::RpcError>> = match $request.method() {
 
                         $(Some($method) => {

--- a/src/examples/simple_device_tokio.rs
+++ b/src/examples/simple_device_tokio.rs
@@ -150,10 +150,7 @@ pub(crate) async fn main() -> shvrpc::Result<()> {
             "getDelayed" [None, Browse] => {
                 let mut resp = request.prepare_response().unwrap_or_default();
                 tokio::task::spawn(async move {
-                    let mut app_state = app_state;
                     let mut counter = app_state
-                        .as_mut()
-                        .expect("Missing state for delay node")
                         .write()
                         .await;
                     let ret_val = {


### PR DESCRIPTION
If `app_state` param is present, it can be assumed that the state has been set and therefore can be extracted right away. (#9)